### PR TITLE
Always return the succeeded status from `result`

### DIFF
--- a/lib/happenings/event.rb
+++ b/lib/happenings/event.rb
@@ -58,6 +58,7 @@ module Happenings
       @succeeded = succeeded
       @message = options[:message]
       @reason = options[:reason]
+      succeeded
     end
 
     def event_name

--- a/spec/happenings/event_spec.rb
+++ b/spec/happenings/event_spec.rb
@@ -47,7 +47,7 @@ describe 'a happening event' do
       before do
         class Event
           def strategy
-            failure! message: 'it did not work'
+            failure! message: 'it did not work', reason: :you_broke_it
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 
 require 'bundler/setup'
+require 'securerandom'
 Bundler.require(:default, :development)
 
 


### PR DESCRIPTION
Hey Desmond, it's Aubrey, I hope you're doing well! I'm working on Alumnifire now and we just hit a small bug with this library where if you pass a reason on failure then it will return the reason from the failure method. Since the reason isn't falsy it broke some stuff for us, and I've changed it to return the status instead.